### PR TITLE
updating for xcode 6.2 and fixing SkipWhile

### DIFF
--- a/SequenceOf+Linq.swift
+++ b/SequenceOf+Linq.swift
@@ -9,8 +9,8 @@ extension SequenceOf {
                 } else {
                     return nil
                 }
-                })
             })
+        })
     }
     
     func Where(f: (T) -> Bool) -> SequenceOf<T> {
@@ -28,8 +28,8 @@ extension SequenceOf {
                         return nil
                     }
                 }
-                })
             })
+        })
     }
     
     func Take(count: Int) -> SequenceOf<T> {
@@ -43,8 +43,8 @@ extension SequenceOf {
                 } else {
                     return nil
                 }
-                })
             })
+        })
     }
     
     func TakeWhile(f: (T) -> Bool) -> SequenceOf<T> {
@@ -64,8 +64,8 @@ extension SequenceOf {
                     }
                 }
                 return nil
-                })
             })
+        })
     }
     
     func TakeUntil(f: (T) -> Bool) -> SequenceOf<T> {
@@ -85,8 +85,8 @@ extension SequenceOf {
                     }
                 }
                 return nil
-                })
             })
+        })
     }
     
     
@@ -103,29 +103,28 @@ extension SequenceOf {
                     }
                 }
                 return generator.next()
-                })
             })
+        })
     }
     
     func SkipWhile(f: (T) -> Bool) -> SequenceOf<T> {
         return SequenceOf<T>({() -> GeneratorOf<T> in
             var generator = self.generate()
-            var conditionMet = true
+            var conditionMet = false
             return GeneratorOf<T>({
-                while (conditionMet) {
+                while !conditionMet {
                     if let value = generator.next() {
-                        if f(value) {
+                        if !f(value) {
+                            conditionMet = true
                             return value
-                        } else {
-                            conditionMet = false
                         }
                     } else {
                         return nil
                     }
                 }
-                return nil
-                })
+                return generator.next()
             })
+        })
     }
     
     
@@ -145,8 +144,8 @@ extension SequenceOf {
                     }
                 }
                 return generator.next()
-                })
             })
+        })
     }
     
     func Any(f: (T) -> Bool) -> Bool {
@@ -193,10 +192,10 @@ extension SequenceOf {
         return generator.next()
     }
     
-    func ToArray() -> T[] {
-        var output = T[]()
+    func ToArray() -> [T] {
+        var output: [T] = []
         for value in self {
-            output += value
+            output += [value]
         }
         return output;
     }


### PR DESCRIPTION
Updates for new Xcode and fixing SkipWhile.  

``` Swift
var numbers = SequenceOf(1...5)
var skipped = numbers.SkipWhile {$0 < 3}

for i in skipped {
    i
}
```

Output:

```
4
5
```
